### PR TITLE
feat: add es6 import for npm module

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,4 +5,3 @@ coverage
 .idea
 .scratch
 scripts
-src

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "version": "2.5.3",
     "description": "JavaScript SDK that encapsulates the TRON Node HTTP API",
     "main": "dist/TronWeb.node.js",
+    "module": "src/index.js",
     "scripts": {
         "prepare": "npm run build",
         "build": "npm run clean && webpack --config webpack.config.js --progress --colors",


### PR DESCRIPTION
Now, this project can import by `compressed code` in `dist` folder, and it is hard for debuging and `tree-shaking`.  So I suggest to add `src` folder for `npm install`。
