### PR TITLE
Allow to create asset without freezing tokens

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tronweb",
-    "version": "2.6.1",
+    "version": "2.6.2",
     "description": "JavaScript SDK that encapsulates the TRON HTTP API",
     "main": "dist/TronWeb.node.js",
     "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import utils from 'utils';
 import BigNumber from 'bignumber.js';
 import EventEmitter from 'eventemitter3';
 import {version} from '../package.json';
+import semver from 'semver';
 
 import TransactionBuilder from 'lib/transactionBuilder';
 import Trx from 'lib/trx';
@@ -134,6 +135,10 @@ export default class TronWeb extends EventEmitter {
         };
 
         this.emit('addressChanged', {hex, base58});
+    }
+
+    fullnodeSatisfies(version) {
+        return semver.satisfies(this.fullnodeVersion, version);
     }
 
     isValidProvider(provider) {

--- a/src/lib/transactionBuilder.js
+++ b/src/lib/transactionBuilder.js
@@ -51,7 +51,7 @@ export default class TransactionBuilder {
             from = this.tronWeb.defaultAddress.hex;
         } else if (utils.isObject(from)) {
             options = from;
-            from  = this.tronWeb.defaultAddress.hex;
+            from = this.tronWeb.defaultAddress.hex;
         }
 
         if (!callback)
@@ -109,7 +109,7 @@ export default class TransactionBuilder {
             from = this.tronWeb.defaultAddress.hex;
         } else if (utils.isObject(from)) {
             options = from;
-            from  = this.tronWeb.defaultAddress.hex;
+            from = this.tronWeb.defaultAddress.hex;
         }
 
         if (!callback)
@@ -171,7 +171,7 @@ export default class TransactionBuilder {
             buyer = this.tronWeb.defaultAddress.hex;
         } else if (utils.isObject(buyer)) {
             options = buyer;
-            buyer  = this.tronWeb.defaultAddress.hex;
+            buyer = this.tronWeb.defaultAddress.hex;
         }
 
         if (!callback)
@@ -232,7 +232,7 @@ export default class TransactionBuilder {
             receiverAddress = undefined;
         } else if (utils.isObject(receiverAddress)) {
             options = receiverAddress;
-            receiverAddress  = undefined;
+            receiverAddress = undefined;
         }
 
         if (utils.isFunction(address)) {
@@ -240,7 +240,7 @@ export default class TransactionBuilder {
             address = this.tronWeb.defaultAddress.hex;
         } else if (utils.isObject(address)) {
             options = address;
-            address  = this.tronWeb.defaultAddress.hex;
+            address = this.tronWeb.defaultAddress.hex;
         }
 
         if (utils.isFunction(duration)) {
@@ -318,7 +318,7 @@ export default class TransactionBuilder {
             receiverAddress = undefined;
         } else if (utils.isObject(receiverAddress)) {
             options = receiverAddress;
-            receiverAddress  = undefined;
+            receiverAddress = undefined;
         }
 
         if (utils.isFunction(address)) {
@@ -326,7 +326,7 @@ export default class TransactionBuilder {
             address = this.tronWeb.defaultAddress.hex;
         } else if (utils.isObject(address)) {
             options = address;
-            address  = this.tronWeb.defaultAddress.hex;
+            address = this.tronWeb.defaultAddress.hex;
         }
 
         if (utils.isFunction(resource)) {
@@ -385,7 +385,7 @@ export default class TransactionBuilder {
             address = this.tronWeb.defaultAddress.hex;
         } else if (utils.isObject(address)) {
             options = address;
-            address  = this.tronWeb.defaultAddress.hex;
+            address = this.tronWeb.defaultAddress.hex;
         }
 
         if (!callback)
@@ -470,7 +470,7 @@ export default class TransactionBuilder {
             voterAddress = this.tronWeb.defaultAddress.hex;
         } else if (utils.isObject(voterAddress)) {
             options = voterAddress;
-            voterAddress  = this.tronWeb.defaultAddress.hex;
+            voterAddress = this.tronWeb.defaultAddress.hex;
         }
 
         if (!callback)
@@ -1015,18 +1015,14 @@ export default class TransactionBuilder {
             start_time: parseInt(saleStart),
             end_time: parseInt(saleEnd),
             free_asset_net_limit: parseInt(freeBandwidth),
-            public_free_asset_net_limit: parseInt(freeBandwidthLimit)
-        }
-        const frozenSupply = {
-            frozen_amount: parseInt(frozenAmount),
-            frozen_days: parseInt(frozenDuration)
-        }
-        if (this.tronWeb.fullnodeSatisfies('^3.6.0')) {
-            if (parseInt(frozenAmount) > 0) {
-                data.frozen_supply = frozenSupply
+            public_free_asset_net_limit: parseInt(freeBandwidthLimit),
+            frozen_supply: {
+                frozen_amount: parseInt(frozenAmount),
+                frozen_days: parseInt(frozenDuration)
             }
-        } else {
-            data.frozen_supply = frozenSupply
+        }
+        if (this.tronWeb.fullnodeSatisfies('>=3.5.0') && !(parseInt(frozenAmount) > 0)) {
+            delete data.frozen_supply
         }
         if (precision && !isNaN(parseInt(precision))) {
             data.precision = parseInt(precision);
@@ -1052,7 +1048,7 @@ export default class TransactionBuilder {
             address = this.tronWeb.defaultAddress.hex;
         } else if (utils.isObject(address)) {
             options = address;
-            address  = this.tronWeb.defaultAddress.hex;
+            address = this.tronWeb.defaultAddress.hex;
         }
 
         if (!callback) {
@@ -1121,7 +1117,6 @@ export default class TransactionBuilder {
             return;
 
 
-
         this.tronWeb.fullNode.request('wallet/setaccountid', {
             account_id: accountId,
             owner_address: toHex(address),
@@ -1134,7 +1129,7 @@ export default class TransactionBuilder {
             issuerAddress = this.tronWeb.defaultAddress.hex;
         } else if (utils.isObject(issuerAddress)) {
             options = issuerAddress;
-            issuerAddress  = this.tronWeb.defaultAddress.hex;
+            issuerAddress = this.tronWeb.defaultAddress.hex;
         }
 
         if (!callback)
@@ -1223,7 +1218,7 @@ export default class TransactionBuilder {
             issuerAddress = this.tronWeb.defaultAddress.hex;
         } else if (utils.isObject(issuerAddress)) {
             options = issuerAddress;
-            issuerAddress  = this.tronWeb.defaultAddress.hex;
+            issuerAddress = this.tronWeb.defaultAddress.hex;
         }
 
         if (!callback)
@@ -1278,7 +1273,7 @@ export default class TransactionBuilder {
             issuerAddress = this.tronWeb.defaultAddress.hex;
         } else if (utils.isObject(issuerAddress)) {
             options = issuerAddress;
-            issuerAddress  = this.tronWeb.defaultAddress.hex;
+            issuerAddress = this.tronWeb.defaultAddress.hex;
         }
 
         if (!callback)
@@ -1326,7 +1321,7 @@ export default class TransactionBuilder {
             voterAddress = this.tronWeb.defaultAddress.hex;
         } else if (utils.isObject(voterAddress)) {
             options = voterAddress;
-            voterAddress  = this.tronWeb.defaultAddress.hex;
+            voterAddress = this.tronWeb.defaultAddress.hex;
         }
 
         if (!callback)
@@ -1381,7 +1376,7 @@ export default class TransactionBuilder {
             ownerAddress = this.tronWeb.defaultAddress.hex;
         } else if (utils.isObject(ownerAddress)) {
             options = ownerAddress;
-            ownerAddress  = this.tronWeb.defaultAddress.hex;
+            ownerAddress = this.tronWeb.defaultAddress.hex;
         }
 
         if (!callback)
@@ -1445,7 +1440,7 @@ export default class TransactionBuilder {
             ownerAddress = this.tronWeb.defaultAddress.hex;
         } else if (utils.isObject(ownerAddress)) {
             options = ownerAddress;
-            ownerAddress  = this.tronWeb.defaultAddress.hex;
+            ownerAddress = this.tronWeb.defaultAddress.hex;
         }
 
         if (!callback)
@@ -1513,7 +1508,7 @@ export default class TransactionBuilder {
             ownerAddress = this.tronWeb.defaultAddress.hex;
         } else if (utils.isObject(ownerAddress)) {
             options = ownerAddress;
-            ownerAddress  = this.tronWeb.defaultAddress.hex;
+            ownerAddress = this.tronWeb.defaultAddress.hex;
         }
 
         if (!callback)
@@ -1575,7 +1570,7 @@ export default class TransactionBuilder {
             ownerAddress = this.tronWeb.defaultAddress.hex;
         } else if (utils.isObject(ownerAddress)) {
             options = ownerAddress;
-            ownerAddress  = this.tronWeb.defaultAddress.hex;
+            ownerAddress = this.tronWeb.defaultAddress.hex;
         }
 
         if (!callback)
@@ -1643,7 +1638,7 @@ export default class TransactionBuilder {
             ownerAddress = this.tronWeb.defaultAddress.hex;
         } else if (utils.isObject(ownerAddress)) {
             options = ownerAddress;
-            ownerAddress  = this.tronWeb.defaultAddress.hex;
+            ownerAddress = this.tronWeb.defaultAddress.hex;
         }
 
         if (!callback)
@@ -1714,7 +1709,7 @@ export default class TransactionBuilder {
             ownerAddress = this.tronWeb.defaultAddress.hex;
         } else if (utils.isObject(ownerAddress)) {
             options = ownerAddress;
-            ownerAddress  = this.tronWeb.defaultAddress.hex;
+            ownerAddress = this.tronWeb.defaultAddress.hex;
         }
 
         if (!callback)
@@ -1773,7 +1768,7 @@ export default class TransactionBuilder {
             ownerAddress = this.tronWeb.defaultAddress.hex;
         } else if (utils.isObject(ownerAddress)) {
             options = ownerAddress;
-            ownerAddress  = this.tronWeb.defaultAddress.hex;
+            ownerAddress = this.tronWeb.defaultAddress.hex;
         }
 
         if (!callback)

--- a/src/lib/transactionBuilder.js
+++ b/src/lib/transactionBuilder.js
@@ -3,7 +3,7 @@ import utils from 'utils';
 import {AbiCoder} from 'utils/ethersUtils';
 import Validator from 'paramValidator';
 import {ADDRESS_PREFIX_REGEX} from 'utils/address';
-
+import semver from 'semver';
 let self;
 
 //helpers
@@ -1015,11 +1015,18 @@ export default class TransactionBuilder {
             start_time: parseInt(saleStart),
             end_time: parseInt(saleEnd),
             free_asset_net_limit: parseInt(freeBandwidth),
-            public_free_asset_net_limit: parseInt(freeBandwidthLimit),
-            frozen_supply: {
-                frozen_amount: parseInt(frozenAmount),
-                frozen_days: parseInt(frozenDuration)
+            public_free_asset_net_limit: parseInt(freeBandwidthLimit)
+        }
+        const frozenSupply = {
+            frozen_amount: parseInt(frozenAmount),
+            frozen_days: parseInt(frozenDuration)
+        }
+        if (semver.satisfies(this.tronWeb.fullnodeVersion, '^3.6.0')) {
+            if (parseInt(frozenAmount) > 0) {
+                data.frozen_supply = frozenSupply
             }
+        } else {
+            data.frozen_supply = frozenSupply
         }
         if (precision && !isNaN(parseInt(precision))) {
             data.precision = parseInt(precision);

--- a/src/lib/transactionBuilder.js
+++ b/src/lib/transactionBuilder.js
@@ -3,7 +3,7 @@ import utils from 'utils';
 import {AbiCoder} from 'utils/ethersUtils';
 import Validator from 'paramValidator';
 import {ADDRESS_PREFIX_REGEX} from 'utils/address';
-import semver from 'semver';
+
 let self;
 
 //helpers
@@ -1021,7 +1021,7 @@ export default class TransactionBuilder {
             frozen_amount: parseInt(frozenAmount),
             frozen_days: parseInt(frozenDuration)
         }
-        if (semver.satisfies(this.tronWeb.fullnodeVersion, '^3.6.0')) {
+        if (this.tronWeb.fullnodeSatisfies('^3.6.0')) {
             if (parseInt(frozenAmount) > 0) {
                 data.frozen_supply = frozenSupply
             }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -114,6 +114,16 @@ describe('TronWeb Instance', function () {
         });
     });
 
+
+    describe('#fullnodeVersion()', function () {
+        it('should verify that the version of the fullNode is available', function () {
+            const tronWeb = tronWebBuilder.createInstance();
+            // setTimeout(() => console.log(tronWeb.fullnodeVersion), 500)
+            assert.equal(typeof tronWeb.fullnodeVersion, 'string');
+
+        });
+    });
+
     describe('#setDefaultBlock()', function () {
         it('should accept a positive integer', function () {
             const tronWeb = tronWebBuilder.createInstance();

--- a/test/lib/transactionBuilder.test.js
+++ b/test/lib/transactionBuilder.test.js
@@ -12,6 +12,7 @@ const assertEqualHex = require('../helpers/assertEqualHex');
 const testRevertContract = require('../fixtures/contracts').testRevert;
 const testConstantContract = require('../fixtures/contracts').testConstant;
 const waitChainData = require('../helpers/waitChainData');
+const semver = require('semver');
 
 const TronWeb = tronWebBuilder.TronWeb;
 const {
@@ -206,6 +207,26 @@ describe('TronWeb.transactionBuilder', function () {
                 assert.equal(transaction.raw_data.contract[0].Permission_id || 0, options.permissionId || 0);
             }
         });
+
+            it(`should create a TestToken without freezing anything in 3.6.0`, async function () {
+                if (semver.satisfies(tronWeb.fullnodeVersion, '^3.6.0')) {
+                    const options = getTokenOptions();
+                    options.totalSupply = '100'
+                    options.frozenAmount = '0'
+                    options.frozenDuration = '0'
+                    options.saleEnd = options.saleEnd.toString()
+                    for (let i = 0; i < 2; i++) {
+                        if (i === 1) options.permissionId = 2;
+                        const transaction = await tronWeb.transactionBuilder.createToken(options);
+                        const parameter = txPars(transaction);
+                        await assertEqualHex(parameter.value.abbr, options.abbreviation);
+                        assert.equal(transaction.raw_data.contract[0].Permission_id || 0, options.permissionId || 0);
+                    }
+                } else {
+                    this.skip()
+                }
+            });
+
 
         it('should throw if an invalid name is passed', async function () {
 

--- a/test/lib/transactionBuilder.test.js
+++ b/test/lib/transactionBuilder.test.js
@@ -12,7 +12,6 @@ const assertEqualHex = require('../helpers/assertEqualHex');
 const testRevertContract = require('../fixtures/contracts').testRevert;
 const testConstantContract = require('../fixtures/contracts').testConstant;
 const waitChainData = require('../helpers/waitChainData');
-const semver = require('semver');
 
 const TronWeb = tronWebBuilder.TronWeb;
 const {
@@ -209,7 +208,7 @@ describe('TronWeb.transactionBuilder', function () {
         });
 
             it(`should create a TestToken without freezing anything in 3.6.0`, async function () {
-                if (semver.satisfies(tronWeb.fullnodeVersion, '^3.6.0')) {
+                if (tronWeb.fullnodeSatisfies('^3.6.0')) {
                     const options = getTokenOptions();
                     options.totalSupply = '100'
                     options.frozenAmount = '0'


### PR DESCRIPTION
When creating an asset with JavaTron 3.6, if the frozenAmount is zero, the transaction is accepted but the field `frozenSupply` must be undefined.