### PR TITLE
Workaround to abi code missed trc10 type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tronweb",
-    "version": "2.6.8",
+    "version": "2.7.0",
     "description": "JavaScript SDK that encapsulates the TRON HTTP API",
     "main": "dist/TronWeb.node.js",
     "scripts": {

--- a/src/utils/abi.js
+++ b/src/utils/abi.js
@@ -20,12 +20,12 @@ export function decodeParams(names, types, output, ignoreMethodHash) {
         throw new Error('The encoded string is not valid. Its length must be a multiple of 64.');
 
     // workaround for unsupported trcToken type
-    // types = types.map(type => {
-    //     if (/trcToken/.test(type)) {
-    //         type = type.replace(/trcToken/, 'uint256')
-    //     }
-    //     return type
-    // })
+    types = types.map(type => {
+        if (/trcToken/.test(type)) {
+            type = type.replace(/trcToken/, 'uint256')
+        }
+        return type
+    })
 
     return abiCoder.decode(types, output).reduce((obj, arg, index) => {
         if (types[index] == 'address')


### PR DESCRIPTION
Uncommenting workaround for unsupported trcToken type. It has been tested in stage.