### PR TITLE
Adding API for JavaTron 3.6.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tronweb",
-    "version": "2.7.2",
+    "version": "2.7.3",
     "description": "JavaScript SDK that encapsulates the TRON HTTP API",
     "main": "dist/TronWeb.node.js",
     "scripts": {

--- a/src/lib/transactionBuilder.js
+++ b/src/lib/transactionBuilder.js
@@ -1966,4 +1966,71 @@ export default class TransactionBuilder {
     }
 
 
+    async getReward(address = this.tronWeb.defaultAddress.hex, options, callback = false) {
+        if (utils.isFunction(options)) {
+            callback = options;
+            options = {};
+        }
+
+        if (utils.isFunction(address)) {
+            callback = address;
+            address = this.tronWeb.defaultAddress.hex;
+        } else if (utils.isObject(address)) {
+            options = address;
+            address = this.tronWeb.defaultAddress.hex;
+        }
+
+        if (!callback)
+            return this.injectPromise(this.getReward, address, options);
+
+        if (this.validator.notValid([
+            {
+                name: 'origin',
+                type: 'address',
+                value: address
+            }
+        ], callback))
+            return;
+
+        const data = {
+            owner_address: toHex(address)
+        };
+
+        this.tronWeb.solidityNode.request('walletsolidity/getReward', data, 'post').then(transaction => resultManager(transaction, callback)).catch(err => callback(err));
+    }
+
+
+    async getBrokerage(address = this.tronWeb.defaultAddress.hex, options, callback = false) {
+        if (utils.isFunction(options)) {
+            callback = options;
+            options = {};
+        }
+
+        if (utils.isFunction(address)) {
+            callback = address;
+            address = this.tronWeb.defaultAddress.hex;
+        } else if (utils.isObject(address)) {
+            options = address;
+            address = this.tronWeb.defaultAddress.hex;
+        }
+
+        if (!callback)
+            return this.injectPromise(this.getBrokerage, address, options);
+
+        if (this.validator.notValid([
+            {
+                name: 'origin',
+                type: 'address',
+                value: address
+            }
+        ], callback))
+            return;
+
+        const data = {
+            owner_address: toHex(address)
+        };
+
+        this.tronWeb.solidityNode.request('walletsolidity/getBrokerage', data, 'post').then(transaction => resultManager(transaction, callback)).catch(err => callback(err));
+    }
+
 }

--- a/src/lib/transactionBuilder.js
+++ b/src/lib/transactionBuilder.js
@@ -9,7 +9,7 @@ let self;
 //helpers
 
 function toHex(value) {
-    return self.tronWeb.address.toHex(value);
+    return TronWeb.address.toHex(value);
 }
 
 function fromUtf8(value) {
@@ -1963,74 +1963,6 @@ export default class TransactionBuilder {
             return this.injectPromise(this.addUpdateData, transaction, data, dataFormat);
 
         this.alterTransaction(transaction, {data, dataFormat}, callback);
-    }
-
-
-    async getReward(address = this.tronWeb.defaultAddress.hex, options, callback = false) {
-        if (utils.isFunction(options)) {
-            callback = options;
-            options = {};
-        }
-
-        if (utils.isFunction(address)) {
-            callback = address;
-            address = this.tronWeb.defaultAddress.hex;
-        } else if (utils.isObject(address)) {
-            options = address;
-            address = this.tronWeb.defaultAddress.hex;
-        }
-
-        if (!callback)
-            return this.injectPromise(this.getReward, address, options);
-
-        if (this.validator.notValid([
-            {
-                name: 'origin',
-                type: 'address',
-                value: address
-            }
-        ], callback))
-            return;
-
-        const data = {
-            owner_address: toHex(address)
-        };
-
-        this.tronWeb.solidityNode.request('walletsolidity/getReward', data, 'post').then(transaction => resultManager(transaction, callback)).catch(err => callback(err));
-    }
-
-
-    async getBrokerage(address = this.tronWeb.defaultAddress.hex, options, callback = false) {
-        if (utils.isFunction(options)) {
-            callback = options;
-            options = {};
-        }
-
-        if (utils.isFunction(address)) {
-            callback = address;
-            address = this.tronWeb.defaultAddress.hex;
-        } else if (utils.isObject(address)) {
-            options = address;
-            address = this.tronWeb.defaultAddress.hex;
-        }
-
-        if (!callback)
-            return this.injectPromise(this.getBrokerage, address, options);
-
-        if (this.validator.notValid([
-            {
-                name: 'origin',
-                type: 'address',
-                value: address
-            }
-        ], callback))
-            return;
-
-        const data = {
-            owner_address: toHex(address)
-        };
-
-        this.tronWeb.solidityNode.request('walletsolidity/getBrokerage', data, 'post').then(transaction => resultManager(transaction, callback)).catch(err => callback(err));
     }
 
 }

--- a/src/lib/trx.js
+++ b/src/lib/trx.js
@@ -5,6 +5,7 @@ import {ADDRESS_PREFIX} from 'utils/address';
 import Validator from "../paramValidator";
 
 const TRX_MESSAGE_HEADER = '\x19TRON Signed Message:\n32';
+// it should be: '\x15TRON Signed Message:\n32';
 const ETH_MESSAGE_HEADER = '\x19Ethereum Signed Message:\n32';
 
 export default class Trx {

--- a/src/lib/trx.js
+++ b/src/lib/trx.js
@@ -8,6 +8,10 @@ const TRX_MESSAGE_HEADER = '\x19TRON Signed Message:\n32';
 // it should be: '\x15TRON Signed Message:\n32';
 const ETH_MESSAGE_HEADER = '\x19Ethereum Signed Message:\n32';
 
+function toHex(value) {
+    return TronWeb.address.toHex(value);
+}
+
 export default class Trx {
     constructor(tronWeb = false) {
         if (!tronWeb || !tronWeb instanceof TronWeb)
@@ -135,7 +139,7 @@ export default class Trx {
         this.getBlock(block).then(({transactions = false}) => {
             if (!transactions)
                 callback('Transaction not found in block');
-            else if (typeof index == 'number'){
+            else if (typeof index == 'number') {
                 if (index >= 0 && index < transactions.length)
                     callback(null, transactions[index]);
                 else
@@ -623,8 +627,8 @@ export default class Trx {
     }
 
     static verifySignature(message, address, signature, useTronHeader = true) {
-        message = message.replace(/^0x/,'');
-        signature = signature.replace(/^0x/,'');
+        message = message.replace(/^0x/, '');
+        signature = signature.replace(/^0x/, '');
         const messageBytes = [
             ...toUtf8Bytes(useTronHeader ? TRX_MESSAGE_HEADER : ETH_MESSAGE_HEADER),
             ...utils.code.hexStr2byteArray(message)
@@ -705,7 +709,7 @@ export default class Trx {
     }
 
     static signString(message, privateKey, useTronHeader = true) {
-        message = message.replace(/^0x/,'');
+        message = message.replace(/^0x/, '');
         const signingKey = new SigningKey(privateKey);
         const messageBytes = [
             ...toUtf8Bytes(useTronHeader ? TRX_MESSAGE_HEADER : ETH_MESSAGE_HEADER),
@@ -1305,6 +1309,107 @@ export default class Trx {
 
             callback(null, this._parseToken(token));
         }).catch(err => callback(err));
+    }
+
+    async getReward(address, options = {}, callback = false) {
+        options.confirmed = true;
+        return this._getReward(address, options, callback);
+    }
+
+    async getUnconfirmedReward(address, options = {}, callback = false) {
+        options.confirmed = false;
+        return this._getReward(address, options, callback);
+    }
+
+    async getBrokerage(address, options = {}, callback = false) {
+        options.confirmed = true;
+        return this._getBrokerage(address, options, callback);
+    }
+
+    async getUnconfirmedBrokerage(address, options = {}, callback = false) {
+        options.confirmed = false;
+        return this._getBrokerage(address, options, callback);
+    }
+
+    async _getReward(address = this.tronWeb.defaultAddress.hex, options, callback = false) {
+        if (utils.isFunction(options)) {
+            callback = options;
+            options = {};
+        }
+
+        if (utils.isFunction(address)) {
+            callback = address;
+            address = this.tronWeb.defaultAddress.hex;
+        } else if (utils.isObject(address)) {
+            options = address;
+            address = this.tronWeb.defaultAddress.hex;
+        }
+
+        if (!callback)
+            return this.injectPromise(this._getReward, address, options);
+
+        if (this.validator.notValid([
+            {
+                name: 'origin',
+                type: 'address',
+                value: address
+            }
+        ], callback))
+            return;
+
+        const data = {
+            owner_address: toHex(address)
+        };
+
+        this.tronWeb[options.confirmed ? 'solidityNode' : 'fullNode'].request(`wallet${options.confirmed ? 'solidity' : ''}/getReward`, data, 'post')
+            .then((result = {}) => {
+
+                if (typeof result.reward === 'undefined')
+                    return callback('Not found.');
+
+                callback(null, result.reward);
+            }).catch(err => callback(err));
+    }
+
+
+    async _getBrokerage(address = this.tronWeb.defaultAddress.hex, options, callback = false) {
+        if (utils.isFunction(options)) {
+            callback = options;
+            options = {};
+        }
+
+        if (utils.isFunction(address)) {
+            callback = address;
+            address = this.tronWeb.defaultAddress.hex;
+        } else if (utils.isObject(address)) {
+            options = address;
+            address = this.tronWeb.defaultAddress.hex;
+        }
+
+        if (!callback)
+            return this.injectPromise(this._getBrokerage, address, options);
+
+        if (this.validator.notValid([
+            {
+                name: 'origin',
+                type: 'address',
+                value: address
+            }
+        ], callback))
+            return;
+
+        const data = {
+            owner_address: toHex(address)
+        };
+
+        this.tronWeb[options.confirmed ? 'solidityNode' : 'fullNode'].request(`wallet${options.confirmed ? 'solidity' : ''}/getBrokerage`, data, 'post')
+            .then((result = {}) => {
+
+                if (typeof result.brokerage === 'undefined')
+                    return callback('Not found.');
+
+                callback(null, result.brokerage);
+            }).catch(err => callback(err));
     }
 
 };

--- a/test/lib/transactionBuilder.test.js
+++ b/test/lib/transactionBuilder.test.js
@@ -1292,7 +1292,7 @@ describe('TronWeb.transactionBuilder', function () {
     });
 
     // TODO fix this, Jackie
-    describe.skip("#triggerSmartContract", async function () {
+    describe("#triggerSmartContract", async function () {
 
         let transaction;
         before(async function () {
@@ -1485,6 +1485,24 @@ describe('TronWeb.transactionBuilder', function () {
                 assert.equal(tronWeb.toUtf8(unconfirmedTx.raw_data.data), data);
 
             });
+
+        });
+    });
+
+    describe("#getReward", async function () {
+        it('should get the reward', async function () {
+
+            let transaction = await tronWeb.transactionBuilder.getReward(accounts[0]);
+            assert.equal(transaction.reward, 0)
+
+        });
+    });
+
+    describe("#getBrokerage", async function () {
+        it('should get the brokerage', async function () {
+
+            let transaction = await tronWeb.transactionBuilder.getBrokerage(accounts[0]);
+            assert.equal(transaction.brokerage, 0)
 
         });
     });

--- a/test/lib/transactionBuilder.test.js
+++ b/test/lib/transactionBuilder.test.js
@@ -1489,23 +1489,4 @@ describe('TronWeb.transactionBuilder', function () {
         });
     });
 
-    describe("#getReward", async function () {
-        it('should get the reward', async function () {
-
-            let transaction = await tronWeb.transactionBuilder.getReward(accounts[0]);
-            assert.equal(transaction.reward, 0)
-
-        });
-    });
-
-    describe("#getBrokerage", async function () {
-        it('should get the brokerage', async function () {
-
-            let transaction = await tronWeb.transactionBuilder.getBrokerage(accounts[0]);
-            assert.equal(transaction.brokerage, 0)
-
-        });
-    });
-
-
 });

--- a/test/lib/trx.test.js
+++ b/test/lib/trx.test.js
@@ -1760,5 +1760,42 @@ describe('TronWeb.trx', function () {
 
     });
 
+    describe("#getReward", async function () {
+        it('should get the reward', async function () {
+
+            let reward = await tronWeb.trx.getReward(accounts[0]);
+            assert.equal(reward, 0)
+
+        });
+    });
+
+    describe("#getUnconfirmedReward", async function () {
+        it('should get the reward', async function () {
+
+            let reward = await tronWeb.trx.getUnconfirmedReward(accounts[0]);
+            assert.equal(reward, 0)
+
+        });
+    });
+
+    describe("#getBrokerage", async function () {
+        it('should get the brokerage', async function () {
+
+            let brokerage = await tronWeb.trx.getBrokerage(accounts[0]);
+            assert.equal(brokerage, 0)
+
+        });
+    });
+
+    describe("#getUnconfirmedBrokerage", async function () {
+        it('should get the brokerage', async function () {
+
+            let brokerage = await tronWeb.trx.getUnconfirmedBrokerage(accounts[0]);
+            assert.equal(brokerage, 0)
+
+        });
+    });
+
+
 
 });


### PR DESCRIPTION
Adding the new api for `JavaTron 3.6.5` for full and solidity node.
- [x] getReward
- [x] getUnconfirmedReward
- [x] getBrokerage
- [x] getUnconfirmedBrokerage
- [ ] updateBrokerage
- [ ] triggerConstantContract
- [ ] WithdrawBalanceContract

