### PR TITLE
fix abi.entrys undefined

### DIFF
--- a/src/lib/contract/index.js
+++ b/src/lib/contract/index.js
@@ -202,7 +202,7 @@ export default class Contract {
             this.bytecode = contract.bytecode;
             this.deployed = true;
 
-            this.loadAbi(contract.abi.entrys);
+            this.loadAbi(contract.abi ? contract.abi.entrys : []);
 
             return callback(null, this);
         } catch (ex) {


### PR DESCRIPTION
If the contract has no abi, the key of that abi may not exist.