### PR TITLE
Fix get token list by name

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,12 @@ In order to contribute you can
 
 ## Recent History
 
+__2.9.1__
+* Fix `trx.getTokenListByName`
+
+__2.9.0__
+* Support smart contracts with function that requires an array of addresses as a parameter, included the constructor during the deployment
+
 __2.8.1__
 * Add options `keepTxID` to show also the txID when triggering a contract with `shouldPollResponse`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "tronweb",
-    "version": "2.9.0",
+    "version": "2.9.1",
     "description": "JavaScript SDK that encapsulates the TRON HTTP API",
     "main": "dist/TronWeb.node.js",
     "scripts": {

--- a/pre-commit-result
+++ b/pre-commit-result
@@ -1,0 +1,1 @@
+Test skipped before git commit.

--- a/pre-commit-result
+++ b/pre-commit-result
@@ -1,1 +1,0 @@
-Test skipped before git commit.

--- a/src/lib/trx.js
+++ b/src/lib/trx.js
@@ -1285,7 +1285,9 @@ export default class Trx {
         this.tronWeb.fullNode.request('wallet/getassetissuelistbyname', {
             value: this.tronWeb.fromUtf8(tokenID)
         }, 'post').then(token => {
-            if (!token.name)
+            if (Array.isArray(token.assetIssue)) {
+                callback(null, token.assetIssue.map(t => this._parseToken(t)));
+            } else if (!token.name)
                 return callback('Token does not exist');
 
             callback(null, this._parseToken(token));

--- a/test-git-hash
+++ b/test-git-hash
@@ -1,0 +1,1 @@
+Test failed.

--- a/test-report
+++ b/test-report
@@ -1,0 +1,58 @@
+
+[0m[0m
+[0m  TronWeb.lib.event[0m
+[0m    Trongrid-compatible version[0m
+[0m      #getEventsByTransactionID[0m
+[33mSleeping for 0.5 seconds...[39m[33m Slept.[39m
+[33m[39m[33mSleeping for 0.5 seconds...[39m[33m Slept.[39m
+[33m[39m[33mSleeping for 0.5 seconds...[39m[33m Slept.[39m
+[33m[39m      [32m  ✓[0m[90m should emit an unconfirmed event and get it[0m[31m (1562ms)[0m
+      [32m  ✓[0m[90m should emit an event, wait for confirmation and get it[0m[31m (9139ms)[0m
+[0m      #getEventsByContractAddress[0m
+      [31m  1) should emit an event and wait for it[0m
+[0m      #contract.method.watch[0m
+      [31m  2) should watch for an event[0m
+      [31m  3) should only watch for an event with given filters[0m
+
+
+[92m [0m[32m 2 passing[0m[90m (11s)[0m
+[31m  3 failing[0m
+
+[0m  1) TronWeb.lib.event
+       Trongrid-compatible version
+         #getEventsByContractAddress
+           should emit an event and wait for it:
+[0m[31m     Error: the object {
+  "error": {
+    "code": 404
+    "status": "Not Found"
+  }
+} was thrown, throw an Error :)[0m[90m
+      at processTicksAndRejections (internal/process/task_queues.js:93:5)
+[0m
+[0m  2) TronWeb.lib.event
+       Trongrid-compatible version
+         #contract.method.watch
+           should watch for an event:
+[0m[31m     Error: the object {
+  "error": {
+    "code": 404
+    "status": "Not Found"
+  }
+} was thrown, throw an Error :)[0m[90m
+      at processTicksAndRejections (internal/process/task_queues.js:93:5)
+[0m
+[0m  3) TronWeb.lib.event
+       Trongrid-compatible version
+         #contract.method.watch
+           should only watch for an event with given filters:
+[0m[31m     Error: the object {
+  "error": {
+    "code": 404
+    "status": "Not Found"
+  }
+} was thrown, throw an Error :)[0m[90m
+      at processTicksAndRejections (internal/process/task_queues.js:93:5)
+[0m
+
+

--- a/test/helpers/waitChainData.js
+++ b/test/helpers/waitChainData.js
@@ -2,6 +2,7 @@ const tronWebBuilder = require('./tronWebBuilder');
 const tronWeb = tronWebBuilder.createInstance();
 const wait = require('./wait');
 const chalk = require('chalk');
+const jlog = require('./jlog');
 
 function log(x) {
     process.stdout.write(chalk.yellow(x))
@@ -42,6 +43,9 @@ module.exports = async function (type, ...params) {
                 }
                 case 'sendToken': {
                     data = await tronWeb.trx.getUnconfirmedAccount(params[0]);
+
+                    jlog(data)
+
                     isFound = data && data.assetV2 && data.assetV2.length && data.assetV2[0].value !== params[1];
                     break;
                 }


### PR DESCRIPTION
This fixes `trx.getTokenListByName`. It is a breaking change, theoretically, because it returns an array instead that a single object but the previous version was broken, so I am not handling it as a breaking change.